### PR TITLE
Add operationId to each action in the API schema

### DIFF
--- a/ActionSchema.json
+++ b/ActionSchema.json
@@ -9,6 +9,7 @@
     "/companyResearch": {
       "post": {
         "description": "Get financial data for a company by name",
+        "operationId": "companyResearch",
         "parameters": [
           {
             "name": "name",
@@ -37,6 +38,7 @@
     "/createPortfolio": {
       "post": {
         "description": "Create a company portfolio of top profit earners by specifying number of companies and industry",
+        "operationId": "createPortfolio",
         "parameters": [
           {
             "name": "numCompanies",
@@ -75,6 +77,7 @@
     "/sendEmail": {
       "post": {
         "description": "Send an email with FOMC search summary and created portfolio",
+        "operationId": "sendEmail",
         "parameters": [
           {
             "name": "emailAddress",


### PR DESCRIPTION
*Issue #, if available:*
#34

*Description of changes:*
Currently Amazon Bedrock is failing to create a new action group using the provided schema due to `operaationId` missing from the actions. I added this parameter with fitting value. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
